### PR TITLE
Add a workaround for a strange behaviour of ZS3 around the bucket name

### DIFF
--- a/src/storage/s3.lisp
+++ b/src/storage/s3.lisp
@@ -3,8 +3,10 @@
   (:use #:cl
         #:mito.attachment.storage)
   (:import-from #:zs3
+                #:*s3-region*
                 #:*s3-endpoint*
                 #:*credentials*
+                #:region-endpoint
                 #:put-file
                 #:put-stream
                 #:delete-object)
@@ -51,8 +53,11 @@
 (defmacro with-s3-storage (storage &body body)
   (once-only (storage)
     `(let ((zs3:*s3-region* (s3-storage-region ,storage))
+           ;; XXX: ZS3 ignores the bucket name if zs3:*s3-endpoint* is different
+           ;;   from the returned value of zs3::region-endpoint.
+           (zs3:*s3-endpoint* (zs3::region-endpoint (s3-storage-region ,storage)))
            (zs3:*credentials* (multiple-value-list
-                               (s3-storage-credentials ,storage))))
+                                (s3-storage-credentials ,storage))))
        ,@body)))
 
 (defmethod store-object-in-storage ((storage s3-storage) (object pathname) file-key)


### PR DESCRIPTION
ZS3 ignores the bucket name if `zs3:*s3-region*` is not "us-east-1" and `zs3:*s3-endpoint*` is "s3.amazonaws.com", which is the default.

https://github.com/xach/zs3/blob/56f2ad9fade7bcbac1c52820940776ea71b60fd6/request.lisp#L259-L263

Perhaps, this is for other storage web services than AWS S3?