### PR TITLE
Fix get-object to return a readable stream

### DIFF
--- a/mito-attachment.asd
+++ b/mito-attachment.asd
@@ -27,14 +27,15 @@
   :components ((:module "src"
                 :components
                 ((:file "mito-attachment" :depends-on ("mixin" "storage" "storage-components"))
-                 (:file "mixin" :depends-on ("storage"))
+                 (:file "mixin" :depends-on ("storage" "util"))
                  (:file "storage")
                  (:module "storage-components"
                   :pathname "storage"
-                  :depends-on ("storage")
+                  :depends-on ("storage" "util")
                   :components
                   ((:file "disk")
-                   (:file "s3"))))))
+                   (:file "s3")))
+                 (:file "util"))))
   :description "Mito mixin class for file management"
   :long-description
   #.(with-open-file (stream (merge-pathnames

--- a/src/mixin.lisp
+++ b/src/mixin.lisp
@@ -8,6 +8,8 @@
                 #:get-object-in-storage
                 #:store-object-in-storage
                 #:delete-object-from-storage)
+  (:import-from #:mito-attachment.util
+                #:slurp-stream)
   (:import-from #:trivial-mimes
                 #:mime-lookup
                 #:mime-file-type)
@@ -107,18 +109,6 @@
   (:method ((attachment attachment))
     (get-object-in-storage *storage*
                            (file-key attachment))))
-
-(defun slurp-stream (stream &optional size)
-  (if size
-      (let ((buffer (make-array size :element-type '(unsigned-byte 8))))
-        (read-sequence buffer stream)
-        buffer)
-      (apply #'concatenate
-             '(simple-array (unsigned-byte 8) (*))
-             (loop with buffer = (make-array 1024 :element-type '(unsigned-byte 8))
-                   for read-bytes = (read-sequence buffer stream)
-                   collect (subseq buffer 0 read-bytes)
-                   while (= read-bytes 1024)))))
 
 (defmethod mito:save-dao :before ((attachment attachment))
   (when (slot-boundp attachment 'content)

--- a/src/storage/disk.lisp
+++ b/src/storage/disk.lisp
@@ -2,9 +2,14 @@
 (defpackage mito.attachment.storage.disk
   (:use #:cl
         #:mito.attachment.storage)
+  (:import-from #:mito-attachment.util
+                #:slurp-stream)
   (:import-from #:lack.component
                 #:lack-component
                 #:call)
+  (:import-from #:flexi-streams
+                #:make-in-memory-input-stream
+                #:make-flexi-stream)
   (:import-from #:alexandria
                 #:copy-stream)
   (:export #:disk-storage
@@ -46,8 +51,10 @@
           file-key))
 
 (defmethod get-object-in-storage ((storage disk-storage) file-key)
-  (open (disk-storage-file storage file-key)
-        :element-type '(unsigned-byte 8)))
+  (with-open-file (in (disk-storage-file storage file-key) :element-type '(unsigned-byte 8))
+    (flex:make-flexi-stream
+      (flex:make-in-memory-input-stream
+        (slurp-stream in)))))
 
 (defmethod store-object-in-storage ((storage disk-storage) (object pathname) file-key)
   (let ((file (disk-storage-file storage file-key)))

--- a/src/storage/s3.lisp
+++ b/src/storage/s3.lisp
@@ -12,7 +12,8 @@
                 #:put-stream
                 #:delete-object)
   (:import-from #:flexi-streams
-                #:make-flexi-stream)
+                #:make-flexi-stream
+                #:make-in-memory-input-stream)
   (:import-from #:alexandria
                 #:once-only)
   (:export #:s3-storage
@@ -69,7 +70,9 @@
           (with-s3-storage storage
             (zs3:get-object (storage-bucket storage) (s3-file-key storage file-key)
                             :output :vector))))
-    (flex:make-flexi-stream content :external-format :utf-8)))
+    (flex:make-flexi-stream
+      (flex:make-in-memory-input-stream content)
+      :external-format :utf-8)))
 
 (defmethod store-object-in-storage ((storage s3-storage) (object pathname) file-key)
   (with-s3-storage storage

--- a/src/storage/s3.lisp
+++ b/src/storage/s3.lisp
@@ -7,9 +7,12 @@
                 #:*s3-endpoint*
                 #:*credentials*
                 #:region-endpoint
+                #:get-object
                 #:put-file
                 #:put-stream
                 #:delete-object)
+  (:import-from #:flexi-streams
+                #:make-flexi-stream)
   (:import-from #:alexandria
                 #:once-only)
   (:export #:s3-storage
@@ -61,9 +64,12 @@
        ,@body)))
 
 (defmethod get-object-in-storage ((storage s3-storage) file-key)
-  (with-s3-storage storage
-    (zs3:get-object (storage-bucket storage) (s3-file-key storage file-key)
-                    :output :stream)))
+  ;; XXX: ZS3 (Drakma) returns a closed stream when specifying ':output :stream' and fails to read.
+  (let ((content
+          (with-s3-storage storage
+            (zs3:get-object (storage-bucket storage) (s3-file-key storage file-key)
+                            :output :vector))))
+    (flex:make-flexi-stream content :external-format :utf-8)))
 
 (defmethod store-object-in-storage ((storage s3-storage) (object pathname) file-key)
   (with-s3-storage storage

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,0 +1,16 @@
+(defpackage #:mito-attachment.util
+  (:use #:cl)
+  (:export #:slurp-stream))
+(in-package #:mito-attachment.util)
+
+(defun slurp-stream (stream &optional size)
+  (if size
+      (let ((buffer (make-array size :element-type '(unsigned-byte 8))))
+        (read-sequence buffer stream)
+        buffer)
+      (apply #'concatenate
+             '(simple-array (unsigned-byte 8) (*))
+             (loop with buffer = (make-array 1024 :element-type '(unsigned-byte 8))
+                   for read-bytes = (read-sequence buffer stream)
+                   collect (subseq buffer 0 read-bytes)
+                   while (= read-bytes 1024)))))


### PR DESCRIPTION
ZS3 (Drakma) returns a closed stream and fails to read it.